### PR TITLE
Feature : Add backup data script

### DIFF
--- a/backup_data.sh
+++ b/backup_data.sh
@@ -1,0 +1,70 @@
+#! /bin/bash
+
+set -o allexport
+source /home/valheim/scripts/config/.env
+set +o allexport
+
+source /home/valheim/scripts/discord_utils.sh
+
+# === CONFIGURATION ===
+SAVE_DIR="/home/valheim/.config/unity3d/IronGate/Valheim/worlds_local"
+BACKUP_DIR="/home/valheim/backups"
+LOG_FILE="/home/valheim/logs/backup_valheim.log"
+TIMESTAMP=$(date +"%Y-%m-%d_%H-%M-%S")
+BACKUP_NAME="world_backup_$TIMESTAMP.tar.gz"
+MAX_BACKUPS=7
+
+WEBHOOK_ID=$VALHEIM_LOGS_WEBHOOK_ID
+
+
+# === CREATION DU FICHIER LOG SI IL N EXISTE PAS ===
+#if [ ! -f "$LOG_FILE" ]; then
+#    touch "$LOG_FILE"
+#    chown :valheim "$LOG_FILE"
+#    chmod 775 "$LOG_FILE"
+#fi
+
+
+# === BACKUP ===
+if [ -d "$SAVE_DIR" ]; then
+    if [ ! -d "$BACKUP_DIR" ]; then
+        embed=$(build_discord_embed \
+            "$(get_emoji "error") Backup error" \
+            "Backup dir not found or does not exist : **${BACKUP_DIR}**" \
+            "red")
+        send_discord_payload $WEBHOOK_ID "$embed"
+        echo "[$(date '+%Yè%m-%d %H:%M:%S')] ERROR : Backup directory not found: $BACKUP_DIR" >> "$LOG_FILE"
+        exit 1
+    fi
+
+    tar -czf "$BACKUP_DIR/$BACKUP_NAME" "$SAVE_DIR"
+
+    embed=$(build_discord_embed \
+        "$(get_emoji "success") Backup successfully" \
+        "Backup name : **${BACKUP_NAME}**" \
+        "green")
+
+    send_discord_payload $WEBHOOK_ID "$embed"
+
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] Backup successful: $BACKUP_NAME" >> "$LOG_FILE"
+else
+    embed=$(build_discord_embed \
+        "$(get_emoji "error") Backup error" \
+        "Save directory not found or does not exist : **${SAVE_DIR}**" \
+        "red")
+    send_discord_payload $WEBHOOK_ID "$embed"
+
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] ERROR: Save directory not found: $SAVE_DIR" >> "$LOG_FILE"
+    exit 1
+fi
+
+# === ROTATION DES BACKUPS ===
+BACKUP_COUNT=$(ls -1 "$BACKUP_DIR"/world_backup_*.tar.gz 2>/dev/null | wc -l)
+
+if [ "$BACKUP_COUNT" -gt "$MAX_BACKUPS" ]; then
+    OLDEST=$(ls -1t "$BACKUP_DIR"/world_backup_*.tar.gz | tail -n +$(($MAX_BACKUPS + 1)))
+    echo "$OLDEST" | while read -r file; do
+        rm -f "$file"
+        echo "[$(date '+%Y-%m-%d %H:%M:%S')] Deleted old backup : $(basename "$file")" >> "$LOG_FILE"
+    done
+fi


### PR DESCRIPTION
## Add Valheim World backup script with log rotation and Discord notifications

Add a bash script to automate the backup of local Valhem world data. It ensures backup are created, old ones are rotated, and status are sent to Discord vie Webhook.

## 🛠️ Added features :
- Automated backup of Valheim save directory ``worlds_local`` into compressed ``.tar.gz`` archives
- Name file with timestamp for identification and sorting.
- Keep only the 7 latest backups, delete the old one automatically.
- Logging all action and error in ``/home/valheim/logs/backup_valheim.log``
- Discord notifications in embed using Discord Webhook.

## 💾 Dependencies :
- Requires environment variable form ``.env`` including ``VALHEIM_LOGS_WEBHOOK_ID`` that represant the Webhook token (id)
- Use utils function from ``discord_utils.sh``

## 🚀 Usage :
- Prefered method is with **cron job** but manually is work too